### PR TITLE
few bugfixes in BUILDLIN.md

### DIFF
--- a/BUILDLIN.md
+++ b/BUILDLIN.md
@@ -121,18 +121,6 @@ Rocks
 
 Currently ubuntu 18.04 has gflags in version 2.2.1 and snappy in version 1.1.7 which are OK
 
-gflags
-```sh
-git clone https://github.com/gflags/gflags.git gflags.git
-cd gflags.git
-git checkout v2.2.2
-
-mkdir _build && cd _build
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DBUILD_SHARED_LIBS=ON ..
-make
-sudo make install
-```
-
 rocks
 ```sh
 git clone https://github.com/nemtech/rocksdb.git rocksdb.git

--- a/BUILDLIN.md
+++ b/BUILDLIN.md
@@ -11,6 +11,7 @@ Prerequisites
  * python 3.x
  * gcc 9.2
  * ninja-build - suggested
+ * curl - suggested
 
 Instructions below are for gcc, but project compiles with clang 9 as well.
 

--- a/BUILDLIN.md
+++ b/BUILDLIN.md
@@ -128,7 +128,7 @@ cd rocksdb.git
 git checkout v6.2.4-nem
 
 mkdir _build && cd _build
-cmake -DCMAKE_BUILD_TYPE=Release -DWITH_TESTS=OFF -DCMAKE_INSTALL_PREFIX=/usr/local ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DWITH_TESTS=OFF -DCMAKE_CXX_FLAGS:STRING="-Wno-error=deprecated-copy" ..
 make
 sudo make install
 ```

--- a/BUILDLIN.md
+++ b/BUILDLIN.md
@@ -128,7 +128,7 @@ cd rocksdb.git
 git checkout v6.2.4-nem
 
 mkdir _build && cd _build
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DWITH_TESTS=OFF -DCMAKE_CXX_FLAGS:STRING="-Wno-error=deprecated-copy -Wno-error=pessimizing-move" ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DWITH_TESTS=OFF ..
 make
 sudo make install
 ```

--- a/BUILDLIN.md
+++ b/BUILDLIN.md
@@ -141,7 +141,7 @@ git clone https://github.com/nemtech/catapult-server.git
 cd catapult-server
 
 mkdir _build && cd _build
-cmake -DBOOST_ROOT=~/boost-build-1.71.0 -DCMAKE_BUILD_TYPE=Release -G Ninja -DGTEST_LIBRARY=~/googletest.git/_build/googlemock/gtest/ -DGTEST_INCLUDE_DIR=~/googletest.git/googletest/include/ -DGTEST_MAIN_LIBRARY=~/googletest.git/_build/googlemock/gtest/libgtest_main.a ..
+cmake -DBOOST_ROOT=~/boost-build-1.71.0 -DCMAKE_BUILD_TYPE=Release -DGTEST_ROOT=/usr/local/ -G Ninja ..
 ninja publish
 ninja -j4
 ```

--- a/BUILDLIN.md
+++ b/BUILDLIN.md
@@ -121,6 +121,18 @@ Rocks
 
 Currently ubuntu 18.04 has gflags in version 2.2.1 and snappy in version 1.1.7 which are OK
 
+gflags
+```sh
+git clone https://github.com/gflags/gflags.git gflags.git
+cd gflags.git
+git checkout v2.2.2
+
+mkdir _build && cd _build
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DBUILD_SHARED_LIBS=ON ..
+make
+sudo make install
+```
+
 rocks
 ```sh
 git clone https://github.com/nemtech/rocksdb.git rocksdb.git
@@ -128,7 +140,7 @@ cd rocksdb.git
 git checkout v6.2.4-nem
 
 mkdir _build && cd _build
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DWITH_TESTS=OFF -DCMAKE_CXX_FLAGS:STRING="-Wno-error=deprecated-copy" ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DWITH_TESTS=OFF -DCMAKE_CXX_FLAGS:STRING="-Wno-error=deprecated-copy -Wno-error=pessimizing-move" ..
 make
 sudo make install
 ```

--- a/BUILDLIN.md
+++ b/BUILDLIN.md
@@ -111,7 +111,7 @@ cd cppzmq.git
 git checkout v4.4.1
 
 mkdir _build && cd _build
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local -DCPPZMQ_BUILD_TESTS=OFF ..
 make
 sudo make install
 ```
@@ -141,7 +141,7 @@ git clone https://github.com/nemtech/catapult-server.git
 cd catapult-server
 
 mkdir _build && cd _build
-cmake -DBOOST_ROOT=~/boost-build-1.71.0 -DCMAKE_BUILD_TYPE=Release -G Ninja ..
+cmake -DBOOST_ROOT=~/boost-build-1.71.0 -DCMAKE_BUILD_TYPE=Release -G Ninja -DGTEST_LIBRARY=~/googletest.git/_build/googlemock/gtest/ -DGTEST_INCLUDE_DIR=~/googletest.git/googletest/include/ -DGTEST_MAIN_LIBRARY=~/googletest.git/_build/googlemock/gtest/libgtest_main.a ..
 ninja publish
 ninja -j4
 ```

--- a/BUILDLIN.md
+++ b/BUILDLIN.md
@@ -143,5 +143,5 @@ cd catapult-server
 mkdir _build && cd _build
 cmake -DBOOST_ROOT=~/boost-build-1.71.0 -DCMAKE_BUILD_TYPE=Release -DGTEST_ROOT=/usr/local/ -G Ninja ..
 ninja publish
-ninja -j4
+ninja -j$(nproc)
 ```


### PR DESCRIPTION
`BUILDLIN.md` uses curl in several places as a _suggested_ tool to download dependencies at specific URLs.

Added curl to the suggested Prerequisites because of that.