### PR TITLE
Add gcc version in docs/BUILD-conan.md

### DIFF
--- a/docs/BUILD-conan.md
+++ b/docs/BUILD-conan.md
@@ -6,7 +6,7 @@ NOTE: Commands are using `\` as marker for line continuations
 
 ## Prerequisites
 
- * gcc 9.2
+ * gcc 9.2, clang 9 or msvc 15.8 (only one is needed, conan will autodetect)
  * cmake (at least 3.14)
  * python 3.x
  * conan https://conan.io

--- a/docs/BUILD-conan.md
+++ b/docs/BUILD-conan.md
@@ -6,6 +6,7 @@ NOTE: Commands are using `\` as marker for line continuations
 
 ## Prerequisites
 
+ * gcc 9.2
  * cmake (at least 3.14)
  * python 3.x
  * conan https://conan.io


### PR DESCRIPTION
It's specified like this in BUILDLIN.md but it's missing in BUILD-conan.md