### PR TITLE
Fix format and links in README files

### DIFF
--- a/docs/RUNNETWORKLIN.md
+++ b/docs/RUNNETWORKLIN.md
@@ -19,7 +19,7 @@ cp ../resources/* resources/
 cp ../tools/nemgen/resources/mijin-test.properties resources/
 ```
 
-WARNING: It is NOT recommended to use the default configuration values in production environments.
+WARNING: Using the default configuration values in production environments is NOT recommended.
 
 ## Generate accounts
 
@@ -32,18 +32,19 @@ cat nemesis.addresses.txt
 
 The script generates ten accounts for the nemesis block, but the number of accounts is customizable.
 
-## Create the seed and txes directory
+## Create the seed and transactions directory
 
-1\. Create a directory to save the generated nemesis block under ``catapult-server/_build``.
+1. Create a directory to save the generated nemesis block under ``catapult-server/_build``.
 
-```sh
-mkdir -p seed/network-test/00000
-```
-2\. Create a directory to save additional transactions embedded in the nemesis block.
+    ```sh
+    mkdir -p seed/network-test/00000
+    ```
 
-```sh
-mkdir txes
-```
+2. Create a directory to save additional transactions embedded in the nemesis block.
+
+    ```sh
+    mkdir txes
+    ```
 
 ## Edit the nemesis block
 
@@ -52,65 +53,65 @@ The first block is defined before launching a new network and sets the initial d
 
 The file ``resources/mijin-test.properties`` defines the transactions issued in the nemesis block.
 
-1\. Open ``mijin-test.properties`` and edit the ``[nemesis]`` section.
+1. Open ``mijin-test.properties`` and edit the ``[nemesis]`` section.
 Replace ``nemesisGenerationHashSeed`` with a unique SHA3-256 hash that will identify the network
 and ``nemesisSignerPrivateKey`` with a private key from ``nemesis.addresses.txt``.
 
-```ini
-[nemesis]
+    ```ini
+    [nemesis]
 
-networkIdentifier = mijin-test
-nemesisGenerationHashSeed = 57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6
-nemesisSignerPrivateKey = 0000000000000000000000000000000000000000000000000000000000000000
-```
+    networkIdentifier = mijin-test
+    nemesisGenerationHashSeed = 57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6
+    nemesisSignerPrivateKey = 0000000000000000000000000000000000000000000000000000000000000000
+    ```
 
-2\. Replace ``[cpp]`` and ``[output]`` sections with the following configuration.
+2. Replace ``[cpp]`` and ``[output]`` sections with the following configuration.
 
-```ini
-[cpp]
+    ```ini
+    [cpp]
 
-cppFileHeader =
+    cppFileHeader =
 
-[output]
+    [output]
 
-cppFile =
-binDirectory = ../seed/network-test
-```
+    cppFile =
+    binDirectory = ../seed/network-test
+    ```
 
-3\. Edit the ``[distribution]`` section.
+3. Edit the ``[distribution]`` section.
 The accounts defined under the distribution list will receive mosaics units.
 Replace at least one address of each group with an address from ``nemesis.addresses.txt``.
 The total amount of units distributed must match the original mosaic definition.
 
-WARNING: Do not add the ``nemesisSignerPrivateKey`` account to the distribution list.
+    WARNING: Do not add the ``nemesisSignerPrivateKey`` account to the distribution list.
 The nemesis signer account cannot announce or participate in transactions.
 The mosaics received by the nemesis account will be lost forever.
 
-Here is an example of how the distribution list looks like after replacing some addresses:
+    Here is an example of how the distribution list looks like after replacing some addresses:
 
-```ini
-[distribution>cat:currency]
+    ```ini
+    [distribution>cat:currency]
 
-SAIBNNG7QJXY54Z334HOKA36NTH7FRRCKFRM4XY = 409'090'909'000'000
-...
+    SAIBNNG7QJXY54Z334HOKA36NTH7FRRCKFRM4XY = 409'090'909'000'000
+    ...
 
-[distribution>cat:harvest]
+    [distribution>cat:harvest]
 
-SBMEZB54VXTH4PRAUJJQJJFB2SNQZQ2SUI6J7BA = 1'000'000
-...
-```
+    SBMEZB54VXTH4PRAUJJQJJFB2SNQZQ2SUI6J7BA = 1'000'000
+    ...
+    ```
 
-Your addresses should be different, as ``catapult.tools.address`` generates different accounts after every execution. Make sure that someone holds the private keys associated with every address listed before the network is launched.
+    Your addresses should be different, as ``catapult.tools.address`` generates different accounts after every execution. Make sure that someone holds the private keys associated with every address listed before the network is launched.
 
-4\. Edit the ``[transactions]`` section.
+4. Edit the ``[transactions]`` section.
 
-```ini
-[transactions]
+    ```ini
+    [transactions]
 
-transactionsDirectory = ../txes
-```
+    transactionsDirectory = ../txes
+    ```
 
-5\. Continue editing the nemesis block properties to fit your network requirements and save the configuration before moving to the next step.
+5. Continue editing the nemesis block properties to fit your network requirements and save the configuration before moving to the next step.
 
 ## Edit the network properties
 
@@ -129,64 +130,65 @@ Each node of the network can host zero or more harvester accounts to create new 
 
 In order to be an eligible harvester, the account must:
 
-1\. Own a certain amount of harvesting mosaics defined in ``config-network.properties`` between ``minHarvesterBalance`` and ``maxHarvesterBalance``.
+1. Own a certain amount of harvesting mosaics defined in ``config-network.properties`` between ``minHarvesterBalance`` and ``maxHarvesterBalance``.
 
-2\. Announce a valid VrfKeyLinkTransaction. The VRF transaction links the harvester account with a second key pair to randomize block production and leader selection.
+2. Announce a valid [VrfKeyLinkTransaction](https://docs.symbolplatform.com/serialization/coresystem.html#vrfkeylinktransaction). The VRF transaction links the harvester account with a second key pair to randomize block production and leader selection.
 
-In order to ensure that the network produces a second block after its launch, the nemesis block must include at least one valid VrfKeyLinkTransaction linking a harvester account with a second key pair.
+    In order to ensure that the network produces a second block after its launch, the nemesis block must include at least one valid VrfKeyLinkTransaction linking a harvester account with a second key pair.
 
-Run the linker tool to create a VrfKeyLinkTransaction. 
+    Run the linker tool to create a VrfKeyLinkTransaction.
 
-```sh
-cd bin
-./catapult.tools.linker --resources ../ --type vrf --secret <HARVESTER_PRIVATE_KEY> --linkedPublicKey <VRF_PUBLIC_KEY> --output ../txes/tx0.bin
-```
+    ```sh
+    cd bin
+    ./catapult.tools.linker --resources ../ --type vrf --secret <HARVESTER_PRIVATE_KEY> --linkedPublicKey <VRF_PUBLIC_KEY> --output ../txes/tx0.bin
+    ```
 
-* Replace ``<HARVESTER_PRIVATE_KEY>`` with the private key of an account that has received sufficient harvesting mosaics in ``resources/mijin-test.properties`` ``[distribution>cat:harvest]``.
+   * Replace ``<HARVESTER_PRIVATE_KEY>`` with the private key of an account that has received sufficient harvesting mosaics in ``resources/mijin-test.properties`` ``[distribution>cat:harvest]``.
 
-* Replace ``<VRF_PUBLIC_KEY>`` with the public key of an unused account from ``nemesis.addresses.txt``.
+   * Replace ``<VRF_PUBLIC_KEY>`` with the public key of an unused account from ``nemesis.addresses.txt``.
 
 ## Generate the network mosaic ids
 
 The network mosaic ids are autogenerated based on the configuration provided in the file ``resources/mijin-test.properties``.
 
-1\. Run the nemesis block generator.
+1. Run the nemesis block generator.
 
-```sh
-./catapult.tools.nemgen --nemesisProperties ../resources/mijin-test.properties
-```
+    ```sh
+    ./catapult.tools.nemgen --nemesisProperties ../resources/mijin-test.properties
+    ```
 
-2\. Copy the currency and harvest mosaic ids displayed on the command line prompt.
+2. Copy the currency and harvest mosaic ids displayed on the command line prompt.
 
-```sh
-(nemgen::NemesisConfigurationLoader.cpp@57) Mosaic Summary
-(nemgen::NemesisConfigurationLoader.cpp@32)  - cat:currency (621EC5B403856FC2)
-...
-(nemgen::NemesisConfigurationLoader.cpp@32)  - cat:harvest (4291ED23000A037A)
-```
-3\. Set ``currencyMosaicId`` and ``harvestingMosaicId`` in ``resources/mijin-test.properties`` with the values generated in the previous step.
+    ```sh
+    (nemgen::NemesisConfigurationLoader.cpp@57) Mosaic Summary
+    (nemgen::NemesisConfigurationLoader.cpp@32)  - cat:currency (621EC5B403856FC2)
+    ...
+    (nemgen::NemesisConfigurationLoader.cpp@32)  - cat:harvest (4291ED23000A037A)
+    ```
 
-```ini
-[chain]
+3. Set ``currencyMosaicId`` and ``harvestingMosaicId`` in ``resources/mijin-test.properties`` with the values generated in the previous step.
 
-currencyMosaicId = 0x621E'C5B4'0385'6FC2
-harvestingMosaicId = 0x4291'ED23'000A'037A
-```
+    ```ini
+    [chain]
+
+    currencyMosaicId = 0x621E'C5B4'0385'6FC2
+    harvestingMosaicId = 0x4291'ED23'000A'037A
+    ```
 
 ## Generate the nemesis block
 
-1\. Run the nemesis block generator a second time, this time with the correct mosaic ids values.
+1. Run the nemesis block generator a second time, this time with the correct mosaic ids values.
 
-```sh
-./catapult.tools.nemgen --nemesisProperties ../resources/mijin-test.properties
-```
+    ```sh
+    ./catapult.tools.nemgen --nemesisProperties ../resources/mijin-test.properties
+    ```
 
-2\. Copy the generated nemesis block under the ``data`` folder.
+2. Copy the generated nemesis block under the ``data`` folder.
 
-```sh
-cd ..
-cp -r seed/network-test/* data/
-```
+    ```sh
+    cd ..
+    cp -r seed/network-test/* data/
+    ```
 
 ## Configure the node
 

--- a/docs/RUNPEERLIN.md
+++ b/docs/RUNPEERLIN.md
@@ -4,13 +4,13 @@ These instructions summarize the minimum number of steps to run a [peer node](ht
 
 ## Prerequisites
 
-* Have defined the network nemesis block. Follow [these instructions](RUNNETWOWORKLIN.md) to run a private network.
-* Have catapult-server compiled in the node. Follow [these instructions](BUILDING.md) to build catapult-server.
+* Have defined the network nemesis block. Follow [these instructions](RUNNETWORKLIN.md) to run a private network.
+* Have catapult-server compiled in the node. Follow [these instructions](BUILDLIN.md) to build catapult-server.
 
 ## Replace the network configuration
 
 NOTE: This step is only required when connecting a peer node to a network that is up and running.
-If you have not launched a network yet, move directly to ["Edit the node properties"](#edit-node-properties).
+If you have not launched a network yet, move directly to ["Edit the node properties"](#edit-the-node-properties).
 
 1\. Download a copy of the following files and folders from the node that originated the network:
 
@@ -29,10 +29,10 @@ cp -r network-config/resources/ resources/
 
 ## Edit the node properties
 
-The file ``resources/config-node.properties`` defines the node configuration. 
+The file ``resources/config-node.properties`` defines the node configuration.
 Learn more about each network property in [this guide](https://nemtech.github.io/guides/network/configuring-node-properties.html#properties).
 
-Open ``resources/config-node.properties`` and search the ``[localnode]`` section.
+Open ``resources/config-node.properties`` and search for the ``[localnode]`` section.
 Then, edit the properties with the peer node details.
 
 ``` ini
@@ -48,29 +48,29 @@ roles = Peer
 This step enables [harvesting](https://nemtech.github.io/concepts/harvesting.html), which allows the node to produce new blocks.
 
 NOTE: At least one node of the network must have harvesting enabled to produce new blocks. If you don't want to enable harvesting, move directly to [Add other peer nodes](#add-other-peer-nodes).
- 
-1\. Open the file ``resources/config-extensions-server.properties`` and enable the harvesting extension.
 
-```ini
-# p2p extensions
-...
-extension.harvesting = true
-...
-```
+1. Open the file ``resources/config-extensions-server.properties`` and enable the harvesting extension.
 
-2\. Edit the file ``resources/config-harvesting.properties``.
+    ```ini
+    # p2p extensions
+    ...
+    extension.harvesting = true
+    ...
+    ```
 
-```ini
-[harvesting]
-harvesterSigningPrivateKey = ``<HARVESTER_SIGNING_PRIVATE_KEY>``
-harvesterVrfPrivateKey = ``<HARVESTER_VRF_PRIVATE_KEY>`` 
-isAutoHarvestingEnabled = true
-...
-```
+2. Edit the file ``resources/config-harvesting.properties``.
 
-* Replace ``<HARVESTER_SIGNING_PRIVATE_KEY>`` with the private key of an [eligible account](https://nemtech.github.io/concepts/harvesting.html#eligibility-criteria).
+    ```ini
+    [harvesting]
+    harvesterSigningPrivateKey = <HARVESTER_SIGNING_PRIVATE_KEY>
+    harvesterVrfPrivateKey = <HARVESTER_VRF_PRIVATE_KEY>
+    isAutoHarvestingEnabled = true
+    ...
+    ```
 
-* Replace ``<HARVESTER_VRF_PRIVATE_KEY>`` with the private key linked to the harvester account to randomize the block production. The link could be defined in the [nemesis block](RUNNETWORKLIN.md#append-the-vrf-keys-to-the-nemesis-block) or at a later point by announcing a **VRFKeyLinkTransaction** with the [CLI](https://github.com/nemtech/symbol-cli/blob/gh-pages/0.20.3.md#vrfkeylink) or [SDKs](https://github.com/nemtech/symbol-sdk-typescript-javascript).
+   * Replace ``<HARVESTER_SIGNING_PRIVATE_KEY>`` with the private key of an [eligible account](https://nemtech.github.io/concepts/harvesting.html#eligibility-criteria).
+
+   * Replace ``<HARVESTER_VRF_PRIVATE_KEY>`` with the private key linked to the harvester account to randomize the block production. The link could be defined in the [nemesis block](RUNNETWORKLIN.md#append-the-vrf-keys-to-the-nemesis-block) or at a later point by announcing a **VRFKeyLinkTransaction** with the [CLI](https://github.com/nemtech/symbol-cli/blob/gh-pages/0.20.3.md#vrfkeylink) or [SDKs](https://github.com/nemtech/symbol-sdk-typescript-javascript).
 
 ## Generate TLS certificates
 
@@ -78,58 +78,58 @@ Catapult uses TLS 1.3 to provide secure connections and identity assurance among
 
 1. To generate and self sign the TLS certificate, you can download and run the script [cert-generate.sh](https://github.com/tech-bureau/catapult-service-bootstrap/blob/master/common/ruby/script/cert-generate.sh) from the ``catapult-server/_build`` directory.
 
-```sh
-mkdir certificate
-cd certificate
-curl https://raw.githubusercontent.com/tech-bureau/catapult-service-bootstrap/master/common/ruby/script/cert-generate.sh --output cert-generate.sh
-chmod 777 cert-generate.sh
-./cert-generate.sh
-```
+    ```sh
+    mkdir certificate
+    cd certificate
+    curl https://raw.githubusercontent.com/tech-bureau/catapult-service-bootstrap/master/common/ruby/script/cert-generate.sh --output cert-generate.sh
+    chmod 777 cert-generate.sh
+    ./cert-generate.sh
+    ```
 
 2. Open ``resources/config-user.properties`` and make sure that ``certificateDirectory`` points to the directory where the TLS certificates are being stored.
 
-```ini
-[storage]
+    ```ini
+    [storage]
 
-dataDirectory = ../data
-certificateDirectory = ../certificate
-pluginsDirectory = .
-...
-```
+    dataDirectory = ../data
+    certificateDirectory = ../certificate
+    pluginsDirectory = .
+    ...
+    ```
 
 ## Add other peer nodes
 
 The file ``resources/peers-p2p.json`` should list strong nodes to serve as beacons.
 A random subset of beacons should be set in each node's peer file for best network performance.
 
-1\. Open the file and replace the public key and host with the public key, host, and port of the node that originated the network.
+1. Open the file and replace the public key and host with the public key, host, and port of the node that originated the network.
 
-```json
-{
-    "_info": "this file contains a list of all trusted peers and can be shared",
-    "knownPeers": [
-        {
-            "publicKey": "0000000000000000000000000000000000000000000000000000000000000000",
-            "endpoint": {
-            "host": "127.0.0.1",
-            "port": 7900
-            },
-            "metadata": {
-                "name": "peernode",
-                "roles": "Peer"
+    ```json
+    {
+        "_info": "this file contains a list of all trusted peers and can be shared",
+        "knownPeers": [
+            {
+                "publicKey": "0000000000000000000000000000000000000000000000000000000000000000",
+                "endpoint": {
+                "host": "127.0.0.1",
+                "port": 7900
+                },
+                "metadata": {
+                    "name": "peernode",
+                    "roles": "Peer"
+                }
             }
-        }
-    ]
-}
-```
+        ]
+    }
+    ```
 
-To get the node public key, run the following command in the folder that contains the node's certificates:
+    To get the node public key, run the following command in the folder that contains the node's certificates:
 
-```sh
-openssl pkey -pubin -in ca.pubkey.pem -noout -text | openssl dgst -sha256 -hex
-```
+    ```sh
+    openssl pkey -pubin -in ca.pubkey.pem -noout -text | openssl dgst -sha256 -hex
+    ```
 
-2\. If the network has more peer nodes, you can add them to the ``knownPeers`` array.
+2. If the network has more peer nodes, you can add them to the ``knownPeers`` array.
 
 ## Run the node
 


### PR DESCRIPTION
- Fix broken links in RUNPEERLIN.md
- Fix format, whitespace and typos:
    Rationale: by using actual markdown lists (1.) instead
    of text lists (1\.) the renderer has the chance to display
    the list items in any way it wants (indented or not).

    Also, the file is easier to read as plain text too.