### PR TITLE
scripts/make.sh - dev-workstation-bootstrap

### DIFF
--- a/docs/BUILD-manual.md
+++ b/docs/BUILD-manual.md
@@ -16,191 +16,45 @@ Required:
 
 These instructions have been verified to work on Ubuntu 20.04 with 8 GB of RAM and 4 CPU cores.
 
-### Installing the prerequisites on Ubuntu
+### Installing the prerequisites on debian/Ubuntu
 
-This code snippet installs the aforementioned prerequisites on apt-based systems (like Ubuntu), creates a `cat_deps_dir` folder under `$HOME` and points `CAT_DEPS_DIR` to it.
+This program installs the aforementioned system-wide prerequisites on apt-based systems (like Ubuntu or debian), creates a directory at the location pointed by the environment variable `CAT_DEPS_DIR`.
 
-Copy & paste it into a terminal (please mind the blank lines):
+## Step 1: Clone catapult-server, prepare the system and environment
 
+Copy & paste the whole snippet below into a terminal:
 ```sh
-sudo apt update
-sudo apt -y upgrade
-sudo apt -y install git gcc g++ cmake curl libssl-dev ninja-build zsh pkg-config
-
-zsh
-
-mkdir -p cat_deps_dir
+git clone https://github.com/nemtech/catapult-server.git
+cd catapult-server
+sudo scripts/make.sh install system_reqs
 export CAT_DEPS_DIR=$HOME/cat_deps_dir
 ```
 
 > **NOTE**:
 > If you want the `CAT_DEPS_DIR` environment variable to persist across sessions make sure to include the last line in the `~/.profile` or `~/.bashrc` files.
 
-## Step 1: Download all dependencies from source
+## Optional step: Download, build and install all dependencies from source
 
-Copy & paste the whole snippet below into a terminal:
-
-```sh
-function download_boost {
-	local boost_ver=1_${1}_0
-	local boost_ver_dotted=1.${1}.0
-
-	curl -o boost_${boost_ver}.tar.gz -SL https://dl.bintray.com/boostorg/release/${boost_ver_dotted}/source/boost_${boost_ver}.tar.gz
-	tar -xzf boost_${boost_ver}.tar.gz
-	mv boost_${boost_ver} boost
-}
-
-function download_git_dependency {
-	git clone git://github.com/${1}/${2}.git
-	cd ${2}
-	git checkout ${3}
-	cd ..
-}
-
-function download_all {
-	download_boost 75
-
-	download_git_dependency google googletest release-1.10.0
-	download_git_dependency google benchmark v1.5.2
-
-	download_git_dependency mongodb mongo-c-driver 1.17.2
-	download_git_dependency mongodb mongo-cxx-driver r3.6.1
-
-	download_git_dependency zeromq libzmq v4.3.3
-	download_git_dependency zeromq cppzmq v4.7.1
-
-	download_git_dependency facebook rocksdb v6.13.3
-}
-
-cd ${CAT_DEPS_DIR}
-mkdir source
-cd source
-download_all
-```
-
-## Step 2: Build and install all dependencies
-
-Copy & paste the whole snippet below into a terminal:
+Type this into a terminal:
 
 ```sh
-boost_output_dir=${CAT_DEPS_DIR}/boost
-
-function install_boost {
-	cd boost
-	./bootstrap.sh with-toolset=clang --prefix=${boost_output_dir}
-
-	b2_options=()
-	b2_options+=(--prefix=${boost_output_dir})
-	./b2 ${b2_options[@]} -j 8 stage release
-	./b2 install ${b2_options[@]}
-}
-
-function install_git_dependency {
-	cd ${2}
-	mkdir _build
-	cd _build
-
-	cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX="${CAT_DEPS_DIR}/${1}" ${cmake_options[@]} ..
-	make -j 8 && make install
-}
-
-function install_google_test {
-	cmake_options=()
-	cmake_options+=(-DCMAKE_POSITION_INDEPENDENT_CODE=ON)
-	install_git_dependency google googletest
-}
-
-function install_google_benchmark {
-	cmake_options=()
-	cmake_options+=(-DBENCHMARK_ENABLE_GTEST_TESTS=OFF)
-	install_git_dependency google benchmark
-}
-
-function install_mongo_c_driver {
-	cmake_options=()
-	cmake_options+=(-DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF)
-	cmake_options+=(-DENABLE_MONGODB_AWS_AUTH=OFF)
-	cmake_options+=(-DENABLE_TESTS=OFF)
-	cmake_options+=(-DENABLE_EXAMPLES=OFF)
-	cmake_options+=(-DENABLE_SASL=OFF)
-	install_git_dependency mongodb mongo-c-driver
-}
-
-function install_mongo_cxx_driver {
-	cmake_options=()
-	cmake_options+=(-DBOOST_ROOT=${boost_output_dir})
-	cmake_options+=(-DCMAKE_CXX_STANDARD=17)
-	install_git_dependency mongodb mongo-cxx-driver
-}
-
-function install_zmq_lib {
-	cmake_options=()
-	cmake_options+=(-DWITH_TLS=OFF)
-	install_git_dependency zeromq libzmq
-}
-
-function install_zmq_cpp {
-	cmake_options=()
-	cmake_options+=(-DCPPZMQ_BUILD_TESTS=OFF)
-	install_git_dependency zeromq cppzmq
-}
-
-function install_rocks {
-	cmake_options=()
-	cmake_options+=(-DPORTABLE=1)
-	cmake_options+=(-DWITH_TESTS=OFF)
-	cmake_options+=(-DWITH_TOOLS=OFF)
-	cmake_options+=(-DWITH_BENCHMARK_TOOLS=OFF)
-	cmake_options+=(-DWITH_CORE_TOOLS=OFF)
-	cmake_options+=(-DWITH_GFLAGS=OFF)
-	install_git_dependency facebook rocksdb
-}
-
-function install_all {
-	declare -a installers=(
-		install_boost
-		install_google_test
-		install_google_benchmark
-		install_mongo_c_driver
-		install_mongo_cxx_driver
-		install_zmq_lib
-		install_zmq_cpp
-		install_rocks
-	)
-	for install in "${installers[@]}"
-	do
-		pushd source > /dev/null
-		${install}
-		popd > /dev/null
-	done
-}
-
-cd ${CAT_DEPS_DIR}
-install_all
+scripts/make.sh install deps
 ```
 
-## Step 3: Download and build catapult
+> **NOTE**:
+> If you only want to download the dependencies (without building and installing them) enter the command ``scripts/make.sh download deps`` instead. Type ``scripts/make.sh --help`` for its summary of commands.
 
-Finally, copy & paste the whole snippet below into a terminal:
+## Step 2: Build catapult
+
+Finally, for building or re-building the software type into a terminal:
 
 ```sh
-git clone https://github.com/nemtech/catapult-server.git
-cd catapult-server
-
-mkdir _build && cd _build
-BOOST_ROOT="${CAT_DEPS_DIR}/boost" cmake .. \
-	-DCMAKE_BUILD_TYPE=RelWithDebInfo \
-	-DCMAKE_PREFIX_PATH="${CAT_DEPS_DIR}/facebook;${CAT_DEPS_DIR}/google;${CAT_DEPS_DIR}/mongodb;${CAT_DEPS_DIR}/zeromq" \
-	\
-	-GNinja
-ninja publish
-ninja -j4
+scripts/make.sh
 ```
 
-> **NOTE:**
-> On macOS, use ':' as separator character instead of ';' for ``CMAKE_PREFIX_PATH``.
+It will handle if you missed the previous optional step.
 
-## Step 4: Installation
+## Step 3: Installation
 
 Once the build finishes successfully, the tools in ``_build/bin`` are ready to use. Optionally, they can be made available globally by running:
 

--- a/scripts/make.sh
+++ b/scripts/make.sh
@@ -1,0 +1,294 @@
+#!/bin/bash
+# This program automates common/essential tasks for building catapult-server
+
+function help {
+	echo "Available commands:"
+	echo "    $prog install system_reqs          Installs apt dependencies. Requires sudo."
+	echo "          debian packages: $debs"
+	echo "    $prog download deps                Obtain 3rd party libs."
+	echo "    $prog install deps                 Compile & install 3rd party libs."
+	echo "    $prog                              Compile catapult-server."
+	if [ "_$CAT_DEPS_DIR" == "_" ]; then
+		echo "Environment variable CAT_DEPS_DIR not set. Required for storing source dependencies."
+		echo "Default value is: $HOME/cat_deps_dir"
+	else
+		echo "Dependencies env.var CAT_DEPS_DIR is set to $CAT_DEPS_DIR"
+	fi
+}
+
+function set_depsdir {
+	depsdir=$CAT_DEPS_DIR
+	boost_output_dir=$depsdir/boost
+	if [ "_$CAT_DEPS_DIR" == "_" ]; then
+		CAT_DEPS_DIR="$HOME/cat_deps_dir"
+		depsdir=$CAT_DEPS_DIR
+		echo "CAT_DEPS_DIR not found in env. Using default: $CAT_DEPS_DIR."
+		warn_env=1
+	fi
+}
+
+function exitok {
+	if [ $warn_env -eq 1 ]; then
+cat << EOF
+Please export the environment variable CAT_DEPS_DIR
+
+  export CAT_DEPS_DIR=$depsdir
+
+Note: If you want the CAT_DEPS_DIR environment variable to persist across sessions make sure to include the last line in the ~/.profile or ~/.bashrc files.
+EOF
+	fi
+	exit 0
+}
+
+function reqroot {
+	if [ "_`whoami`" != "_root" ]; then
+	  echo "Please run as root. (or use sudo)"
+	  exit 1
+	fi
+}
+
+function download_boost {
+	local boost_ver=1_${1}_0
+	local boost_ver_dotted=1.${1}.0
+
+	curl -o boost_${boost_ver}.tar.gz -SL https://dl.bintray.com/boostorg/release/${boost_ver_dotted}/source/boost_${boost_ver}.tar.gz
+	tar -xzf boost_${boost_ver}.tar.gz
+	mv boost_${boost_ver} boost
+}
+
+function download_git_dependency {
+	git clone git://github.com/${1}/${2}.git
+	cd ${2}
+	git checkout ${3}
+	cd ..
+}
+
+function download_all {
+	download_boost 75
+
+	download_git_dependency google googletest release-1.10.0
+	download_git_dependency google benchmark v1.5.2
+
+	download_git_dependency mongodb mongo-c-driver 1.17.2
+	download_git_dependency mongodb mongo-cxx-driver r3.6.1
+
+	download_git_dependency zeromq libzmq v4.3.3
+	download_git_dependency zeromq cppzmq v4.7.1
+
+	download_git_dependency facebook rocksdb v6.13.3
+}
+
+function install_boost {
+	cd boost
+	./bootstrap.sh with-toolset=clang --prefix=${boost_output_dir}
+
+	b2_options=()
+	b2_options+=(--prefix=${boost_output_dir})
+	./b2 ${b2_options[@]} -j $jobs stage release
+	./b2 install ${b2_options[@]}
+}
+
+function install_git_dependency {
+	cd ${2}
+	mkdir _build
+	cd _build
+
+	cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX="$depsdir/${1}" ${cmake_options[@]} ..
+	make -j $jobs && make install
+}
+
+function install_google_test {
+	cmake_options=()
+	cmake_options+=(-DCMAKE_POSITION_INDEPENDENT_CODE=ON)
+	install_git_dependency google googletest
+}
+
+function install_google_benchmark {
+	cmake_options=()
+	cmake_options+=(-DBENCHMARK_ENABLE_GTEST_TESTS=OFF)
+	install_git_dependency google benchmark
+}
+
+function install_mongo_c_driver {
+	cmake_options=()
+	cmake_options+=(-DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF)
+	cmake_options+=(-DENABLE_MONGODB_AWS_AUTH=OFF)
+	cmake_options+=(-DENABLE_TESTS=OFF)
+	cmake_options+=(-DENABLE_EXAMPLES=OFF)
+	cmake_options+=(-DENABLE_SASL=OFF)
+	install_git_dependency mongodb mongo-c-driver
+}
+
+function install_mongo_cxx_driver {
+	cmake_options=()
+	cmake_options+=(-DBOOST_ROOT=${boost_output_dir})
+	cmake_options+=(-DCMAKE_CXX_STANDARD=17)
+	install_git_dependency mongodb mongo-cxx-driver
+}
+
+function install_zmq_lib {
+	cmake_options=()
+	cmake_options+=(-DWITH_TLS=OFF)
+	install_git_dependency zeromq libzmq
+}
+
+function install_zmq_cpp {
+	cmake_options=()
+	cmake_options+=(-DCPPZMQ_BUILD_TESTS=OFF)
+	install_git_dependency zeromq cppzmq
+}
+
+function install_rocks {
+	cmake_options=()
+	cmake_options+=(-DPORTABLE=1)
+	cmake_options+=(-DWITH_TESTS=OFF)
+	cmake_options+=(-DWITH_TOOLS=OFF)
+	cmake_options+=(-DWITH_BENCHMARK_TOOLS=OFF)
+	cmake_options+=(-DWITH_CORE_TOOLS=OFF)
+	cmake_options+=(-DWITH_GFLAGS=OFF)
+	install_git_dependency facebook rocksdb
+}
+
+function install_all {
+	declare -a installers=(
+		install_boost
+		install_google_test
+		install_google_benchmark
+		install_mongo_c_driver
+		install_mongo_cxx_driver
+		install_zmq_lib
+		install_zmq_cpp
+		install_rocks
+	)
+	for install in "${installers[@]}"
+	do
+		pushd source > /dev/null
+			${install}
+		popd > /dev/null
+	done
+}
+
+#-------------------------------------------------------
+
+function install_system_reqs {
+	reqroot
+	set -e
+	apt update
+	apt -y upgrade
+	apt -y install $debs
+	set +e
+}
+
+force_download=0
+
+function download_deps {
+	if [ -d $depsdir ]; then
+		echo -n "Warning: ${depsdir} already exists. "
+		if [ ${force_download} -eq 0 ]; then
+			echo "Download skipped."
+			return
+		fi
+		echo ""
+	fi
+	mkdir -p $depsdir
+	set -e
+	pushd $depsdir > /dev/null
+		mkdir -p source
+		pushd source > /dev/null
+			download_all
+		popd
+	popd
+	set +e
+}
+
+function install_deps {
+	if [ ! -d ${boost_output_dir} ]; then
+		download_deps
+	fi
+	pushd $depsdir > /dev/null
+		install_all
+	popd
+}
+
+#-------------------------------------------------------
+
+function install_main {
+	cmd=$1
+	shift
+	if [ "_$cmd" == "_system_reqs" ]; then
+		install_system_reqs $@
+		exitok
+	elif [ "_$cmd" == "_deps" ]; then
+		set_depsdir
+		install_deps $@
+		exitok
+	fi
+}
+
+depsdir=""
+boost_output_dir=""
+
+function download {
+	cmd=$1
+	shift
+	set_depsdir
+	if [ "_$cmd" == "_deps" ]; then
+		force_download=1
+		download_deps $@
+		exitok
+	fi
+}
+
+function build_catapult {
+	set_depsdir
+	
+	echo "building using ${jobs} jobs"
+	echo "dependencies dir: ${depsdir}"
+        if [ ! -d ${boost_output_dir} ]; then
+                install_deps
+        fi
+	echo "dependencies OK at: ${depsdir}"
+	mkdir -p _build
+	sep=";"
+	if [[ "$OSTYPE" == "darwin"* ]]; then
+		sep=":"
+	fi
+	set -e
+	pushd _build > /dev/null
+		BOOST_ROOT="${depsdir}/boost" cmake .. \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DCMAKE_PREFIX_PATH="${depsdir}/facebook${sep}${depsdir}/google${sep}${depsdir}/mongodb${sep}${depsdir}/zeromq" \
+		\
+		-GNinja
+		ninja publish
+		ninja -j${jobs}
+	popd
+	set +e
+	exitok
+}
+
+#-------------------------------------------------------
+
+prog=$0
+jobs=8
+warn_env=0
+debs="git gcc g++ cmake curl libssl-dev ninja-build zsh pkg-config"
+
+cmd=$1
+shift
+
+if [ "_$cmd" == "_install" ]; then
+	install_main $@
+elif [ "_$cmd" == "_download" ]; then
+	download $@
+elif [ "_$cmd" == "_" ]; then
+	build_catapult $@
+fi
+
+#error flow
+help
+exit 1
+
+
+
+


### PR DESCRIPTION
    the file docs/BUILD-manual describes the process for executing clone->build->rebuild->....
    I found it improveable since it wouldn't suite my needs for easy travelling throught.
    
    I created scripts/make.sh automatizing the tasks described in docs/BUILD-manual.
    macOs users invoke CMake differently. The program handles. (it should work on macOS - It is not tested though)
    
    tested on: linux/bash 5.1
    Need tests on: MacOS
    
    It doesn't alter the current infrastructure, nothing can break foreseeable.
    
    Note: It is possible that the zsh dependency be no longer needed, I haven't removed it because I cannot evaluate the risk.
    The process has been tested successfully in bash 5.1 (the default shell in debian/unstable) successfully.

