### PR TITLE
CMake required version: from 3.14 to 3.13.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 project(catapult_server)
 option(ENABLE_CODE_COVERAGE "Enable code coverage" OFF)
 option(ENABLE_TESTS "Enable tests" ON)

--- a/extensions/CMakeLists.txt
+++ b/extensions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 include_directories(.)
 include_directories(${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/src)

--- a/extensions/addressextraction/CMakeLists.txt
+++ b/extensions/addressextraction/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension(addressextraction)

--- a/extensions/addressextraction/src/CMakeLists.txt
+++ b/extensions/addressextraction/src/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_src(addressextraction)

--- a/extensions/addressextraction/tests/CMakeLists.txt
+++ b/extensions/addressextraction/tests/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_test(addressextraction test)

--- a/extensions/diagnostics/CMakeLists.txt
+++ b/extensions/diagnostics/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension(diagnostics)

--- a/extensions/diagnostics/src/CMakeLists.txt
+++ b/extensions/diagnostics/src/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_src(diagnostics)

--- a/extensions/diagnostics/tests/CMakeLists.txt
+++ b/extensions/diagnostics/tests/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_test(diagnostics)

--- a/extensions/filespooling/CMakeLists.txt
+++ b/extensions/filespooling/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension(filespooling)

--- a/extensions/filespooling/src/CMakeLists.txt
+++ b/extensions/filespooling/src/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_src(filespooling)

--- a/extensions/filespooling/tests/CMakeLists.txt
+++ b/extensions/filespooling/tests/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_test(filespooling test)

--- a/extensions/finalization/CMakeLists.txt
+++ b/extensions/finalization/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension(finalization)

--- a/extensions/finalization/src/CMakeLists.txt
+++ b/extensions/finalization/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_src(finalization api chain handlers io ionet model)
 target_link_libraries(catapult.finalization catapult.consumers catapult.crypto_voting)

--- a/extensions/finalization/tests/CMakeLists.txt
+++ b/extensions/finalization/tests/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_test(finalization api chain handlers io model test)

--- a/extensions/harvesting/CMakeLists.txt
+++ b/extensions/harvesting/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension(harvesting)

--- a/extensions/harvesting/src/CMakeLists.txt
+++ b/extensions/harvesting/src/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_src(harvesting)

--- a/extensions/harvesting/tests/CMakeLists.txt
+++ b/extensions/harvesting/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_test(harvesting test)
 target_link_libraries(tests.catapult.harvesting tests.catapult.test.crypto)

--- a/extensions/hashcache/CMakeLists.txt
+++ b/extensions/hashcache/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension(hashcache)

--- a/extensions/hashcache/src/CMakeLists.txt
+++ b/extensions/hashcache/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_src(hashcache)
 

--- a/extensions/hashcache/tests/CMakeLists.txt
+++ b/extensions/hashcache/tests/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_test(hashcache)

--- a/extensions/mongo/CMakeLists.txt
+++ b/extensions/mongo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 message("--- locating mongo dependencies ---")
 find_package(MONGOCXX 3.6.1 EXACT REQUIRED)

--- a/extensions/mongo/plugins/CMakeLists.txt
+++ b/extensions/mongo/plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_CATAPULT_LIBS catapult.mongo)
 

--- a/extensions/mongo/plugins/account_link/CMakeLists.txt
+++ b/extensions/mongo/plugins/account_link/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 include_directories(.)
 add_subdirectory(src)

--- a/extensions/mongo/plugins/account_link/src/CMakeLists.txt
+++ b/extensions/mongo/plugins/account_link/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_BASE_NAME catapult.mongo.plugins.accountlink)
 

--- a/extensions/mongo/plugins/account_link/tests/CMakeLists.txt
+++ b/extensions/mongo/plugins/account_link/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.mongo.plugins.accountlink)
 

--- a/extensions/mongo/plugins/aggregate/CMakeLists.txt
+++ b/extensions/mongo/plugins/aggregate/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 include_directories(.)
 add_subdirectory(src)

--- a/extensions/mongo/plugins/aggregate/src/CMakeLists.txt
+++ b/extensions/mongo/plugins/aggregate/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_BASE_NAME catapult.mongo.plugins.aggregate)
 

--- a/extensions/mongo/plugins/aggregate/tests/CMakeLists.txt
+++ b/extensions/mongo/plugins/aggregate/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.mongo.plugins.aggregate)
 

--- a/extensions/mongo/plugins/lock_hash/CMakeLists.txt
+++ b/extensions/mongo/plugins/lock_hash/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 include_directories(.)
 add_subdirectory(src)

--- a/extensions/mongo/plugins/lock_hash/src/CMakeLists.txt
+++ b/extensions/mongo/plugins/lock_hash/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_BASE_NAME catapult.mongo.plugins.lockhash)
 

--- a/extensions/mongo/plugins/lock_hash/tests/CMakeLists.txt
+++ b/extensions/mongo/plugins/lock_hash/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.mongo.plugins.lockhash)
 

--- a/extensions/mongo/plugins/lock_hash/tests/int/CMakeLists.txt
+++ b/extensions/mongo/plugins/lock_hash/tests/int/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.int.mongo.plugins.lockhash)
 

--- a/extensions/mongo/plugins/lock_hash/tests/test/CMakeLists.txt
+++ b/extensions/mongo/plugins/lock_hash/tests/test/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_mongo_plugin_test_library(tests.catapult.test.mongo.plugins.lockhash)

--- a/extensions/mongo/plugins/lock_secret/CMakeLists.txt
+++ b/extensions/mongo/plugins/lock_secret/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 include_directories(.)
 add_subdirectory(src)

--- a/extensions/mongo/plugins/lock_secret/src/CMakeLists.txt
+++ b/extensions/mongo/plugins/lock_secret/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_BASE_NAME catapult.mongo.plugins.locksecret)
 

--- a/extensions/mongo/plugins/lock_secret/tests/CMakeLists.txt
+++ b/extensions/mongo/plugins/lock_secret/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.mongo.plugins.locksecret)
 

--- a/extensions/mongo/plugins/lock_secret/tests/int/CMakeLists.txt
+++ b/extensions/mongo/plugins/lock_secret/tests/int/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.int.mongo.plugins.locksecret)
 

--- a/extensions/mongo/plugins/lock_secret/tests/test/CMakeLists.txt
+++ b/extensions/mongo/plugins/lock_secret/tests/test/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_mongo_plugin_test_library(tests.catapult.test.mongo.plugins.locksecret)

--- a/extensions/mongo/plugins/lock_shared/CMakeLists.txt
+++ b/extensions/mongo/plugins/lock_shared/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 include_directories(.)
 add_subdirectory(src)

--- a/extensions/mongo/plugins/lock_shared/src/CMakeLists.txt
+++ b/extensions/mongo/plugins/lock_shared/src/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_header_only_target(catapult.mongo.plugins.lockshared mappers storages)

--- a/extensions/mongo/plugins/lock_shared/tests/CMakeLists.txt
+++ b/extensions/mongo/plugins/lock_shared/tests/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_header_only_target(tests.catapult.mongo.plugins.lockshared int/storages mappers test)

--- a/extensions/mongo/plugins/metadata/CMakeLists.txt
+++ b/extensions/mongo/plugins/metadata/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 include_directories(.)
 add_subdirectory(src)

--- a/extensions/mongo/plugins/metadata/src/CMakeLists.txt
+++ b/extensions/mongo/plugins/metadata/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_BASE_NAME catapult.mongo.plugins.metadata)
 

--- a/extensions/mongo/plugins/metadata/tests/CMakeLists.txt
+++ b/extensions/mongo/plugins/metadata/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.mongo.plugins.metadata)
 

--- a/extensions/mongo/plugins/metadata/tests/int/CMakeLists.txt
+++ b/extensions/mongo/plugins/metadata/tests/int/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.int.mongo.plugins.metadata)
 

--- a/extensions/mongo/plugins/metadata/tests/test/CMakeLists.txt
+++ b/extensions/mongo/plugins/metadata/tests/test/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_mongo_plugin_test_library(tests.catapult.test.mongo.plugins.metadata)

--- a/extensions/mongo/plugins/mosaic/CMakeLists.txt
+++ b/extensions/mongo/plugins/mosaic/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 include_directories(.)
 add_subdirectory(src)

--- a/extensions/mongo/plugins/mosaic/src/CMakeLists.txt
+++ b/extensions/mongo/plugins/mosaic/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_BASE_NAME catapult.mongo.plugins.mosaic)
 

--- a/extensions/mongo/plugins/mosaic/tests/CMakeLists.txt
+++ b/extensions/mongo/plugins/mosaic/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.mongo.plugins.mosaic)
 

--- a/extensions/mongo/plugins/mosaic/tests/int/CMakeLists.txt
+++ b/extensions/mongo/plugins/mosaic/tests/int/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.int.mongo.plugins.mosaic)
 

--- a/extensions/mongo/plugins/mosaic/tests/test/CMakeLists.txt
+++ b/extensions/mongo/plugins/mosaic/tests/test/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_mongo_plugin_test_library(tests.catapult.test.mongo.plugins.mosaic)

--- a/extensions/mongo/plugins/multisig/CMakeLists.txt
+++ b/extensions/mongo/plugins/multisig/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 include_directories(.)
 add_subdirectory(src)

--- a/extensions/mongo/plugins/multisig/src/CMakeLists.txt
+++ b/extensions/mongo/plugins/multisig/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_BASE_NAME catapult.mongo.plugins.multisig)
 

--- a/extensions/mongo/plugins/multisig/tests/CMakeLists.txt
+++ b/extensions/mongo/plugins/multisig/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.mongo.plugins.multisig)
 

--- a/extensions/mongo/plugins/multisig/tests/int/CMakeLists.txt
+++ b/extensions/mongo/plugins/multisig/tests/int/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.int.mongo.plugins.multisig)
 

--- a/extensions/mongo/plugins/multisig/tests/test/CMakeLists.txt
+++ b/extensions/mongo/plugins/multisig/tests/test/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_mongo_plugin_test_library(tests.catapult.test.mongo.plugins.multisig)

--- a/extensions/mongo/plugins/namespace/CMakeLists.txt
+++ b/extensions/mongo/plugins/namespace/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 include_directories(.)
 add_subdirectory(src)

--- a/extensions/mongo/plugins/namespace/src/CMakeLists.txt
+++ b/extensions/mongo/plugins/namespace/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_BASE_NAME catapult.mongo.plugins.namespace)
 

--- a/extensions/mongo/plugins/namespace/tests/CMakeLists.txt
+++ b/extensions/mongo/plugins/namespace/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.mongo.plugins.namespace)
 

--- a/extensions/mongo/plugins/namespace/tests/int/CMakeLists.txt
+++ b/extensions/mongo/plugins/namespace/tests/int/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.int.mongo.plugins.namespace)
 

--- a/extensions/mongo/plugins/namespace/tests/test/CMakeLists.txt
+++ b/extensions/mongo/plugins/namespace/tests/test/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_mongo_plugin_test_library(tests.catapult.test.mongo.plugins.namespace)

--- a/extensions/mongo/plugins/restriction_account/CMakeLists.txt
+++ b/extensions/mongo/plugins/restriction_account/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 include_directories(.)
 add_subdirectory(src)

--- a/extensions/mongo/plugins/restriction_account/src/CMakeLists.txt
+++ b/extensions/mongo/plugins/restriction_account/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_BASE_NAME catapult.mongo.plugins.restrictionaccount)
 

--- a/extensions/mongo/plugins/restriction_account/tests/CMakeLists.txt
+++ b/extensions/mongo/plugins/restriction_account/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.mongo.plugins.restrictionaccount)
 

--- a/extensions/mongo/plugins/restriction_account/tests/int/CMakeLists.txt
+++ b/extensions/mongo/plugins/restriction_account/tests/int/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.int.mongo.plugins.restrictionaccount)
 

--- a/extensions/mongo/plugins/restriction_account/tests/test/CMakeLists.txt
+++ b/extensions/mongo/plugins/restriction_account/tests/test/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_mongo_plugin_test_library(tests.catapult.test.mongo.plugins.restrictionaccount)

--- a/extensions/mongo/plugins/restriction_mosaic/CMakeLists.txt
+++ b/extensions/mongo/plugins/restriction_mosaic/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 include_directories(.)
 add_subdirectory(src)

--- a/extensions/mongo/plugins/restriction_mosaic/src/CMakeLists.txt
+++ b/extensions/mongo/plugins/restriction_mosaic/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_BASE_NAME catapult.mongo.plugins.restrictionmosaic)
 

--- a/extensions/mongo/plugins/restriction_mosaic/tests/CMakeLists.txt
+++ b/extensions/mongo/plugins/restriction_mosaic/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.mongo.plugins.restrictionmosaic)
 

--- a/extensions/mongo/plugins/restriction_mosaic/tests/int/CMakeLists.txt
+++ b/extensions/mongo/plugins/restriction_mosaic/tests/int/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.int.mongo.plugins.restrictionmosaic)
 

--- a/extensions/mongo/plugins/restriction_mosaic/tests/test/CMakeLists.txt
+++ b/extensions/mongo/plugins/restriction_mosaic/tests/test/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_mongo_plugin_test_library(tests.catapult.test.mongo.plugins.restrictionmosaic)

--- a/extensions/mongo/plugins/transfer/CMakeLists.txt
+++ b/extensions/mongo/plugins/transfer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 include_directories(.)
 add_subdirectory(src)

--- a/extensions/mongo/plugins/transfer/src/CMakeLists.txt
+++ b/extensions/mongo/plugins/transfer/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_BASE_NAME catapult.mongo.plugins.transfer)
 

--- a/extensions/mongo/plugins/transfer/tests/CMakeLists.txt
+++ b/extensions/mongo/plugins/transfer/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.mongo.plugins.transfer)
 

--- a/extensions/mongo/src/CMakeLists.txt
+++ b/extensions/mongo/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME catapult.mongo)
 

--- a/extensions/mongo/tests/CMakeLists.txt
+++ b/extensions/mongo/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.mongo)
 

--- a/extensions/mongo/tests/int/CMakeLists.txt
+++ b/extensions/mongo/tests/int/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.int.mongo)
 

--- a/extensions/mongo/tests/test/CMakeLists.txt
+++ b/extensions/mongo/tests/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_add_gtest_dependencies()
 catapult_library_target(tests.catapult.test.mongo mocks)

--- a/extensions/networkheight/CMakeLists.txt
+++ b/extensions/networkheight/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension(networkheight)

--- a/extensions/networkheight/src/CMakeLists.txt
+++ b/extensions/networkheight/src/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_src(networkheight)

--- a/extensions/networkheight/tests/CMakeLists.txt
+++ b/extensions/networkheight/tests/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_test(networkheight)

--- a/extensions/nodediscovery/CMakeLists.txt
+++ b/extensions/nodediscovery/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension(nodediscovery)

--- a/extensions/nodediscovery/src/CMakeLists.txt
+++ b/extensions/nodediscovery/src/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_src(nodediscovery api handlers)

--- a/extensions/nodediscovery/tests/CMakeLists.txt
+++ b/extensions/nodediscovery/tests/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_test(nodediscovery api handlers test)

--- a/extensions/packetserver/CMakeLists.txt
+++ b/extensions/packetserver/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension(packetserver)

--- a/extensions/packetserver/src/CMakeLists.txt
+++ b/extensions/packetserver/src/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_src(packetserver)

--- a/extensions/packetserver/tests/CMakeLists.txt
+++ b/extensions/packetserver/tests/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_test(packetserver)

--- a/extensions/partialtransaction/CMakeLists.txt
+++ b/extensions/partialtransaction/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension(partialtransaction)

--- a/extensions/partialtransaction/src/CMakeLists.txt
+++ b/extensions/partialtransaction/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_src(partialtransaction api chain handlers)
 target_link_libraries(catapult.partialtransaction catapult.consumers catapult.plugins.aggregate.sdk)

--- a/extensions/partialtransaction/tests/CMakeLists.txt
+++ b/extensions/partialtransaction/tests/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_test(partialtransaction api chain handlers test)

--- a/extensions/pluginhandlers/CMakeLists.txt
+++ b/extensions/pluginhandlers/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension(pluginhandlers)

--- a/extensions/pluginhandlers/src/CMakeLists.txt
+++ b/extensions/pluginhandlers/src/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_src(pluginhandlers)

--- a/extensions/pluginhandlers/tests/CMakeLists.txt
+++ b/extensions/pluginhandlers/tests/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_test(pluginhandlers)

--- a/extensions/sync/CMakeLists.txt
+++ b/extensions/sync/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension(sync)

--- a/extensions/sync/src/CMakeLists.txt
+++ b/extensions/sync/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_src(sync)
 target_link_libraries(catapult.sync catapult.consumers)

--- a/extensions/sync/tests/CMakeLists.txt
+++ b/extensions/sync/tests/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_test(sync)

--- a/extensions/syncsource/CMakeLists.txt
+++ b/extensions/syncsource/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension(syncsource)

--- a/extensions/syncsource/src/CMakeLists.txt
+++ b/extensions/syncsource/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_src(syncsource)
 target_link_libraries(catapult.syncsource catapult.io)

--- a/extensions/syncsource/tests/CMakeLists.txt
+++ b/extensions/syncsource/tests/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_test(syncsource)

--- a/extensions/timesync/CMakeLists.txt
+++ b/extensions/timesync/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension(timesync)

--- a/extensions/timesync/src/CMakeLists.txt
+++ b/extensions/timesync/src/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_src(timesync api filters handlers)

--- a/extensions/timesync/tests/CMakeLists.txt
+++ b/extensions/timesync/tests/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_test(timesync api filters handlers test)

--- a/extensions/transactionsink/CMakeLists.txt
+++ b/extensions/transactionsink/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension(transactionsink)

--- a/extensions/transactionsink/src/CMakeLists.txt
+++ b/extensions/transactionsink/src/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_src(transactionsink)

--- a/extensions/transactionsink/tests/CMakeLists.txt
+++ b/extensions/transactionsink/tests/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_test(transactionsink)

--- a/extensions/unbondedpruning/CMakeLists.txt
+++ b/extensions/unbondedpruning/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension(unbondedpruning)

--- a/extensions/unbondedpruning/src/CMakeLists.txt
+++ b/extensions/unbondedpruning/src/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_src(unbondedpruning)

--- a/extensions/unbondedpruning/tests/CMakeLists.txt
+++ b/extensions/unbondedpruning/tests/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_extension_test(unbondedpruning)

--- a/extensions/zeromq/CMakeLists.txt
+++ b/extensions/zeromq/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 message("--- locating zeromq dependencies ---")
 find_package(cppzmq 4.7.1 EXACT REQUIRED)

--- a/extensions/zeromq/src/CMakeLists.txt
+++ b/extensions/zeromq/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME catapult.zeromq)
 

--- a/extensions/zeromq/tests/CMakeLists.txt
+++ b/extensions/zeromq/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.zeromq)
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 project(external)
 add_definitions(-DNO_MISALIGNED_ACCESSES) # sha3
 

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 include_directories(${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/src)
 

--- a/plugins/coresystem/CMakeLists.txt
+++ b/plugins/coresystem/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 include_directories(.)
 add_subdirectory(src)

--- a/plugins/coresystem/src/CMakeLists.txt
+++ b/plugins/coresystem/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_BASE_NAME catapult.plugins.coresystem)
 

--- a/plugins/coresystem/tests/CMakeLists.txt
+++ b/plugins/coresystem/tests/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.plugins.coresystem cache importance model observers plugins validators)

--- a/plugins/services/CMakeLists.txt
+++ b/plugins/services/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 add_subdirectory(hashcache)
 add_subdirectory(signature)

--- a/plugins/services/hashcache/CMakeLists.txt
+++ b/plugins/services/hashcache/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 include_directories(.)
 add_subdirectory(src)

--- a/plugins/services/hashcache/src/CMakeLists.txt
+++ b/plugins/services/hashcache/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_BASE_NAME catapult.plugins.hashcache)
 

--- a/plugins/services/hashcache/tests/CMakeLists.txt
+++ b/plugins/services/hashcache/tests/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.plugins.hashcache cache cache handlers observers plugins validators test)

--- a/plugins/services/signature/CMakeLists.txt
+++ b/plugins/services/signature/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 include_directories(.)
 add_subdirectory(src)

--- a/plugins/services/signature/src/CMakeLists.txt
+++ b/plugins/services/signature/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_BASE_NAME catapult.plugins.signature)
 

--- a/plugins/services/signature/tests/CMakeLists.txt
+++ b/plugins/services/signature/tests/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.plugins.signature cache plugins validators)

--- a/plugins/txes/CMakeLists.txt
+++ b/plugins/txes/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 function(catapult_tx_plugin_src PLUGIN_BASE_NAME)
 	# create an sdk lib

--- a/plugins/txes/account_link/CMakeLists.txt
+++ b/plugins/txes/account_link/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_DEPS_FOLDERS model observers validators)
 

--- a/plugins/txes/account_link/src/CMakeLists.txt
+++ b/plugins/txes/account_link/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_BASE_NAME catapult.plugins.accountlink)
 

--- a/plugins/txes/account_link/tests/CMakeLists.txt
+++ b/plugins/txes/account_link/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.plugins.accountlink)
 

--- a/plugins/txes/aggregate/CMakeLists.txt
+++ b/plugins/txes/aggregate/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_SDK_FOLDERS model)
 set(PLUGIN_DEPS_FOLDERS config validators)

--- a/plugins/txes/aggregate/src/CMakeLists.txt
+++ b/plugins/txes/aggregate/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_BASE_NAME catapult.plugins.aggregate)
 

--- a/plugins/txes/aggregate/tests/CMakeLists.txt
+++ b/plugins/txes/aggregate/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.plugins.aggregate)
 

--- a/plugins/txes/lock_hash/CMakeLists.txt
+++ b/plugins/txes/lock_hash/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_DEPS_FOLDERS cache config model observers state validators)
 

--- a/plugins/txes/lock_hash/src/CMakeLists.txt
+++ b/plugins/txes/lock_hash/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_BASE_NAME catapult.plugins.lockhash)
 

--- a/plugins/txes/lock_hash/tests/CMakeLists.txt
+++ b/plugins/txes/lock_hash/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 add_subdirectory(test)
 

--- a/plugins/txes/lock_hash/tests/test/CMakeLists.txt
+++ b/plugins/txes/lock_hash/tests/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_add_gtest_dependencies()
 catapult_library_target(tests.catapult.test.plugins.lockhash)

--- a/plugins/txes/lock_secret/CMakeLists.txt
+++ b/plugins/txes/lock_secret/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_DEPS_FOLDERS cache config model observers state validators)
 

--- a/plugins/txes/lock_secret/src/CMakeLists.txt
+++ b/plugins/txes/lock_secret/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_BASE_NAME catapult.plugins.locksecret)
 

--- a/plugins/txes/lock_secret/tests/CMakeLists.txt
+++ b/plugins/txes/lock_secret/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 add_subdirectory(test)
 

--- a/plugins/txes/lock_secret/tests/test/CMakeLists.txt
+++ b/plugins/txes/lock_secret/tests/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_add_gtest_dependencies()
 catapult_library_target(tests.catapult.test.plugins.locksecret)

--- a/plugins/txes/lock_shared/CMakeLists.txt
+++ b/plugins/txes/lock_shared/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 include_directories(.)
 add_subdirectory(src)

--- a/plugins/txes/lock_shared/src/CMakeLists.txt
+++ b/plugins/txes/lock_shared/src/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_header_only_target(catapult.plugins.lockshared cache model observers state validators)

--- a/plugins/txes/lock_shared/tests/CMakeLists.txt
+++ b/plugins/txes/lock_shared/tests/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_header_only_target(tests.catapult.plugins.lockshared cache observers state test validators)

--- a/plugins/txes/metadata/CMakeLists.txt
+++ b/plugins/txes/metadata/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_SDK_FOLDERS model state)
 set(PLUGIN_DEPS_FOLDERS cache config observers validators)

--- a/plugins/txes/metadata/src/CMakeLists.txt
+++ b/plugins/txes/metadata/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_BASE_NAME catapult.plugins.metadata)
 

--- a/plugins/txes/metadata/tests/CMakeLists.txt
+++ b/plugins/txes/metadata/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 add_subdirectory(test)
 

--- a/plugins/txes/metadata/tests/test/CMakeLists.txt
+++ b/plugins/txes/metadata/tests/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_add_gtest_dependencies()
 catapult_library_target(tests.catapult.test.plugins.metadata cache)

--- a/plugins/txes/mosaic/CMakeLists.txt
+++ b/plugins/txes/mosaic/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_SDK_FOLDERS model state)
 set(PLUGIN_DEPS_FOLDERS cache config observers validators)

--- a/plugins/txes/mosaic/src/CMakeLists.txt
+++ b/plugins/txes/mosaic/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_BASE_NAME catapult.plugins.mosaic)
 

--- a/plugins/txes/mosaic/tests/CMakeLists.txt
+++ b/plugins/txes/mosaic/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 add_subdirectory(test)
 

--- a/plugins/txes/mosaic/tests/test/CMakeLists.txt
+++ b/plugins/txes/mosaic/tests/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_add_gtest_dependencies()
 catapult_library_target(tests.catapult.test.plugins.mosaic cache)

--- a/plugins/txes/multisig/CMakeLists.txt
+++ b/plugins/txes/multisig/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_DEPS_FOLDERS cache config model observers state validators)
 

--- a/plugins/txes/multisig/src/CMakeLists.txt
+++ b/plugins/txes/multisig/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_BASE_NAME catapult.plugins.multisig)
 

--- a/plugins/txes/multisig/tests/CMakeLists.txt
+++ b/plugins/txes/multisig/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.plugins.multisig)
 

--- a/plugins/txes/namespace/CMakeLists.txt
+++ b/plugins/txes/namespace/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_SDK_FOLDERS model state)
 set(PLUGIN_DEPS_FOLDERS cache config observers validators)

--- a/plugins/txes/namespace/src/CMakeLists.txt
+++ b/plugins/txes/namespace/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_BASE_NAME catapult.plugins.namespace)
 

--- a/plugins/txes/namespace/tests/CMakeLists.txt
+++ b/plugins/txes/namespace/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 add_subdirectory(test)
 

--- a/plugins/txes/namespace/tests/test/CMakeLists.txt
+++ b/plugins/txes/namespace/tests/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_add_gtest_dependencies()
 catapult_library_target(tests.catapult.test.plugins.namespace cache)

--- a/plugins/txes/restriction_account/CMakeLists.txt
+++ b/plugins/txes/restriction_account/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_SDK_FOLDERS model state)
 set(PLUGIN_DEPS_FOLDERS cache config observers validators)

--- a/plugins/txes/restriction_account/src/CMakeLists.txt
+++ b/plugins/txes/restriction_account/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_BASE_NAME catapult.plugins.restrictionaccount)
 

--- a/plugins/txes/restriction_account/tests/CMakeLists.txt
+++ b/plugins/txes/restriction_account/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 add_subdirectory(test)
 

--- a/plugins/txes/restriction_account/tests/test/CMakeLists.txt
+++ b/plugins/txes/restriction_account/tests/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_add_gtest_dependencies()
 catapult_library_target(tests.catapult.test.plugins.restrictionaccount cache)

--- a/plugins/txes/restriction_mosaic/CMakeLists.txt
+++ b/plugins/txes/restriction_mosaic/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_DEPS_FOLDERS cache config model observers state validators)
 

--- a/plugins/txes/restriction_mosaic/src/CMakeLists.txt
+++ b/plugins/txes/restriction_mosaic/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_BASE_NAME catapult.plugins.restrictionmosaic)
 

--- a/plugins/txes/restriction_mosaic/tests/CMakeLists.txt
+++ b/plugins/txes/restriction_mosaic/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 add_subdirectory(test)
 

--- a/plugins/txes/restriction_mosaic/tests/test/CMakeLists.txt
+++ b/plugins/txes/restriction_mosaic/tests/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_add_gtest_dependencies()
 catapult_library_target(tests.catapult.test.plugins.restrictionmosaic cache)

--- a/plugins/txes/transfer/CMakeLists.txt
+++ b/plugins/txes/transfer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_DEPS_FOLDERS config model observers validators)
 

--- a/plugins/txes/transfer/src/CMakeLists.txt
+++ b/plugins/txes/transfer/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(PLUGIN_BASE_NAME catapult.plugins.transfer)
 

--- a/plugins/txes/transfer/tests/CMakeLists.txt
+++ b/plugins/txes/transfer/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.plugins.transfer)
 

--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME resources)
 file(GLOB ${TARGET_NAME}_FILES "*.properties" "*.json")

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 include_directories(. ${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/src)
 

--- a/sdk/src/CMakeLists.txt
+++ b/sdk/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME catapult.sdk)
 

--- a/sdk/tests/CMakeLists.txt
+++ b/sdk/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.sdk)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 include_directories(${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/src)
 

--- a/src/catapult/CMakeLists.txt
+++ b/src/catapult/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 project(catapult)
 
 add_subdirectory(api)

--- a/src/catapult/api/CMakeLists.txt
+++ b/src/catapult/api/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(catapult.api)
 target_link_libraries(catapult.api catapult.io catapult.ionet catapult.model)

--- a/src/catapult/cache/CMakeLists.txt
+++ b/src/catapult/cache/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(catapult.cache)
 target_link_libraries(catapult.cache catapult.cache_db catapult.io catapult.model catapult.tree)

--- a/src/catapult/cache_core/CMakeLists.txt
+++ b/src/catapult/cache_core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(catapult.cache_core)
 target_link_libraries(catapult.cache_core catapult.cache catapult.state)

--- a/src/catapult/cache_db/CMakeLists.txt
+++ b/src/catapult/cache_db/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME catapult.cache_db)
 

--- a/src/catapult/cache_tx/CMakeLists.txt
+++ b/src/catapult/cache_tx/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(catapult.cache_tx)

--- a/src/catapult/chain/CMakeLists.txt
+++ b/src/catapult/chain/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(catapult.chain)
 target_link_libraries(catapult.chain

--- a/src/catapult/config/CMakeLists.txt
+++ b/src/catapult/config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(catapult.config)
 target_link_libraries(catapult.config catapult.ionet)

--- a/src/catapult/consumers/CMakeLists.txt
+++ b/src/catapult/consumers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(catapult.consumers)
 target_link_libraries(catapult.consumers catapult.chain)

--- a/src/catapult/crypto/CMakeLists.txt
+++ b/src/catapult/crypto/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 include_directories(../../../external)
 

--- a/src/catapult/crypto_voting/CMakeLists.txt
+++ b/src/catapult/crypto_voting/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(catapult.crypto_voting)
 target_link_libraries(catapult.crypto_voting catapult.crypto)

--- a/src/catapult/deltaset/CMakeLists.txt
+++ b/src/catapult/deltaset/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_header_only_target(catapult.deltaset)

--- a/src/catapult/disruptor/CMakeLists.txt
+++ b/src/catapult/disruptor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(catapult.disruptor)
 target_link_libraries(catapult.disruptor catapult.model)

--- a/src/catapult/extensions/CMakeLists.txt
+++ b/src/catapult/extensions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(catapult.extensions)
 target_link_libraries(catapult.extensions catapult.chain catapult.net catapult.plugins catapult.subscribers)

--- a/src/catapult/handlers/CMakeLists.txt
+++ b/src/catapult/handlers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(catapult.handlers)
 target_link_libraries(catapult.handlers catapult.io catapult.ionet catapult.model)

--- a/src/catapult/io/CMakeLists.txt
+++ b/src/catapult/io/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(catapult.io)
 target_link_libraries(catapult.io catapult.config catapult.model)

--- a/src/catapult/ionet/CMakeLists.txt
+++ b/src/catapult/ionet/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(catapult.ionet)
 target_link_libraries(catapult.ionet catapult.model catapult.thread)

--- a/src/catapult/keylink/CMakeLists.txt
+++ b/src/catapult/keylink/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_header_only_target(catapult.keylink)

--- a/src/catapult/local/CMakeLists.txt
+++ b/src/catapult/local/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(catapult.local)
 target_link_libraries(catapult.local catapult.extensions)

--- a/src/catapult/local/broker/CMakeLists.txt
+++ b/src/catapult/local/broker/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(catapult.local.broker)
 target_link_libraries(catapult.local.broker catapult.local)

--- a/src/catapult/local/recovery/CMakeLists.txt
+++ b/src/catapult/local/recovery/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(catapult.local.recovery)
 target_link_libraries(catapult.local.recovery catapult.local)

--- a/src/catapult/local/server/CMakeLists.txt
+++ b/src/catapult/local/server/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(catapult.local.server)
 target_link_libraries(catapult.local.server catapult.local catapult.handlers catapult.net)

--- a/src/catapult/model/CMakeLists.txt
+++ b/src/catapult/model/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(catapult.model)
 target_link_libraries(catapult.model catapult.crypto)

--- a/src/catapult/net/CMakeLists.txt
+++ b/src/catapult/net/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(catapult.net)
 target_link_libraries(catapult.net catapult.ionet catapult.thread)

--- a/src/catapult/observers/CMakeLists.txt
+++ b/src/catapult/observers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(catapult.observers)
 target_link_libraries(catapult.observers catapult.cache)

--- a/src/catapult/plugins/CMakeLists.txt
+++ b/src/catapult/plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 # statically link against plugins so that they're available in PluginLoader
 catapult_library_target(catapult.plugins)

--- a/src/catapult/process/CMakeLists.txt
+++ b/src/catapult/process/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(catapult.process)
 target_link_libraries(catapult.process catapult.version)

--- a/src/catapult/process/broker/CMakeLists.txt
+++ b/src/catapult/process/broker/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME catapult.broker)
 

--- a/src/catapult/process/recovery/CMakeLists.txt
+++ b/src/catapult/process/recovery/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME catapult.recovery)
 

--- a/src/catapult/process/server/CMakeLists.txt
+++ b/src/catapult/process/server/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME catapult.server)
 

--- a/src/catapult/state/CMakeLists.txt
+++ b/src/catapult/state/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(catapult.state)

--- a/src/catapult/subscribers/CMakeLists.txt
+++ b/src/catapult/subscribers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(catapult.subscribers)
 target_link_libraries(catapult.subscribers catapult.cache catapult.cache_tx catapult.config catapult.validators)

--- a/src/catapult/thread/CMakeLists.txt
+++ b/src/catapult/thread/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(catapult.thread)
 target_link_libraries(catapult.thread catapult.model catapult.utils)

--- a/src/catapult/tree/CMakeLists.txt
+++ b/src/catapult/tree/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(catapult.tree)
 target_link_libraries(catapult.tree catapult.crypto)

--- a/src/catapult/utils/CMakeLists.txt
+++ b/src/catapult/utils/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(catapult.utils traits)

--- a/src/catapult/validators/CMakeLists.txt
+++ b/src/catapult/validators/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(catapult.validators)
 target_link_libraries(catapult.validators catapult.cache catapult.thread)

--- a/src/catapult/version/CMakeLists.txt
+++ b/src/catapult/version/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 add_definitions(-DCATAPULT_VERSION_DESCRIPTION="${CATAPULT_VERSION_DESCRIPTION}")
 catapult_library_target(catapult.version)

--- a/src/catapult/version/nix/CMakeLists.txt
+++ b/src/catapult/version/nix/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_object_library(catapult.version.nix what_version.cpp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 include_directories(${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/src)
 

--- a/tests/bench/CMakeLists.txt
+++ b/tests/bench/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 # find and set benchmark includes
 function(catapult_add_benchmark_dependencies TARGET_NAME)

--- a/tests/bench/crypto/CMakeLists.txt
+++ b/tests/bench/crypto/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 add_subdirectory(hashers)
 add_subdirectory(verify)

--- a/tests/bench/crypto/hashers/CMakeLists.txt
+++ b/tests/bench/crypto/hashers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_bench_executable_target(bench.catapult.crypto.hashers)
 target_link_libraries(bench.catapult.crypto.hashers catapult.crypto bench.catapult.bench.nodeps)

--- a/tests/bench/crypto/verify/CMakeLists.txt
+++ b/tests/bench/crypto/verify/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_bench_executable_target(bench.catapult.crypto.verify)
 target_link_libraries(bench.catapult.crypto.verify catapult.crypto bench.catapult.bench.nodeps)

--- a/tests/bench/nodeps/CMakeLists.txt
+++ b/tests/bench/nodeps/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(bench.catapult.bench.nodeps)
 catapult_add_benchmark_dependencies(bench.catapult.bench.nodeps)

--- a/tests/catapult/CMakeLists.txt
+++ b/tests/catapult/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 project(tests.catapult)
 
 add_subdirectory(api)

--- a/tests/catapult/api/CMakeLists.txt
+++ b/tests/catapult/api/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.api core utils)

--- a/tests/catapult/cache/CMakeLists.txt
+++ b/tests/catapult/cache/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.cache cache test)
 target_link_libraries(tests.catapult.cache catapult.crypto)

--- a/tests/catapult/cache_core/CMakeLists.txt
+++ b/tests/catapult/cache_core/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.cache_core cache)

--- a/tests/catapult/cache_db/CMakeLists.txt
+++ b/tests/catapult/cache_db/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.cache_db)
 

--- a/tests/catapult/cache_tx/CMakeLists.txt
+++ b/tests/catapult/cache_tx/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.cache_tx cache test)

--- a/tests/catapult/chain/CMakeLists.txt
+++ b/tests/catapult/chain/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.chain cache test)

--- a/tests/catapult/config/CMakeLists.txt
+++ b/tests/catapult/config/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.config net)

--- a/tests/catapult/consumers/CMakeLists.txt
+++ b/tests/catapult/consumers/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.consumers cache test)

--- a/tests/catapult/crypto/CMakeLists.txt
+++ b/tests/catapult/crypto/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 include_directories(../../../external)
 

--- a/tests/catapult/crypto_voting/CMakeLists.txt
+++ b/tests/catapult/crypto_voting/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.crypto_voting core test)
 target_link_libraries(tests.catapult.crypto_voting tests.catapult.test.crypto)

--- a/tests/catapult/deltaset/CMakeLists.txt
+++ b/tests/catapult/deltaset/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 if(MSVC)
 	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /bigobj")

--- a/tests/catapult/disruptor/CMakeLists.txt
+++ b/tests/catapult/disruptor/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.disruptor core test)

--- a/tests/catapult/extensions/CMakeLists.txt
+++ b/tests/catapult/extensions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.extensions local)
 target_link_libraries(tests.catapult.extensions catapult.plugins.coresystem.deps tests.catapult.test.nemesis)

--- a/tests/catapult/handlers/CMakeLists.txt
+++ b/tests/catapult/handlers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.handlers net)
 target_link_libraries(tests.catapult.handlers catapult.tree)

--- a/tests/catapult/io/CMakeLists.txt
+++ b/tests/catapult/io/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.io core test)

--- a/tests/catapult/ionet/CMakeLists.txt
+++ b/tests/catapult/ionet/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.ionet net)
 catapult_add_openssl_dependencies(tests.catapult.ionet)

--- a/tests/catapult/keylink/CMakeLists.txt
+++ b/tests/catapult/keylink/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target_header_only(tests.catapult.keylink cache)
 target_link_libraries(tests.catapult.keylink catapult.observers catapult.validators)

--- a/tests/catapult/local/CMakeLists.txt
+++ b/tests/catapult/local/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 add_subdirectory(broker)
 add_subdirectory(recovery)

--- a/tests/catapult/local/broker/CMakeLists.txt
+++ b/tests/catapult/local/broker/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.local.broker local test)
 target_link_libraries(tests.catapult.local.broker catapult.plugins.signature) # allow signature to be loaded implicitly

--- a/tests/catapult/local/recovery/CMakeLists.txt
+++ b/tests/catapult/local/recovery/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.local.recovery local test)
 target_link_libraries(tests.catapult.local.recovery tests.catapult.test.nemesis)

--- a/tests/catapult/local/server/CMakeLists.txt
+++ b/tests/catapult/local/server/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.local.server local)
 target_link_libraries(tests.catapult.local.server tests.catapult.test.nemesis)

--- a/tests/catapult/model/CMakeLists.txt
+++ b/tests/catapult/model/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.model core)
 target_link_libraries(tests.catapult.model external)

--- a/tests/catapult/net/CMakeLists.txt
+++ b/tests/catapult/net/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.net net)
 target_link_libraries(tests.catapult.net catapult.api)

--- a/tests/catapult/observers/CMakeLists.txt
+++ b/tests/catapult/observers/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.observers cache test)

--- a/tests/catapult/plugins/CMakeLists.txt
+++ b/tests/catapult/plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.plugins core)
 target_link_libraries(tests.catapult.plugins catapult.plugins.transfer) # allow transfer to be loaded implicitly

--- a/tests/catapult/state/CMakeLists.txt
+++ b/tests/catapult/state/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.state core)

--- a/tests/catapult/subscribers/CMakeLists.txt
+++ b/tests/catapult/subscribers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.subscribers cache test)
 target_link_libraries(tests.catapult.subscribers catapult.config)

--- a/tests/catapult/thread/CMakeLists.txt
+++ b/tests/catapult/thread/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.thread core)

--- a/tests/catapult/tree/CMakeLists.txt
+++ b/tests/catapult/tree/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.tree nodeps)

--- a/tests/catapult/utils/CMakeLists.txt
+++ b/tests/catapult/utils/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.utils nodeps test)

--- a/tests/catapult/validators/CMakeLists.txt
+++ b/tests/catapult/validators/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_test_executable_target(tests.catapult.validators cache test)

--- a/tests/int/CMakeLists.txt
+++ b/tests/int/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 # used to define a catapult int test executable by combining catapult_test_executable and catapult_target
 function(catapult_int_test_executable_target TARGET_NAME)

--- a/tests/int/node/CMakeLists.txt
+++ b/tests/int/node/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 add_subdirectory(basic)
 add_subdirectory(stress)

--- a/tests/int/node/basic/CMakeLists.txt
+++ b/tests/int/node/basic/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.int.node)
 

--- a/tests/int/node/stress/CMakeLists.txt
+++ b/tests/int/node/stress/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.int.node.stress)
 

--- a/tests/int/node/test/CMakeLists.txt
+++ b/tests/int/node/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_add_gtest_dependencies()
 catapult_library_target(tests.catapult.int.node.test)

--- a/tests/int/stress/CMakeLists.txt
+++ b/tests/int/stress/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME tests.catapult.int.stress)
 

--- a/tests/test/CMakeLists.txt
+++ b/tests/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_add_gtest_dependencies()
 

--- a/tests/test/cache/CMakeLists.txt
+++ b/tests/test/cache/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(tests.catapult.test.cache)
 target_link_libraries(tests.catapult.test.cache tests.catapult.test.core catapult.cache catapult.cache_core catapult.cache_tx)

--- a/tests/test/core/CMakeLists.txt
+++ b/tests/test/core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(tests.catapult.test.core mocks)
 target_link_libraries(tests.catapult.test.core

--- a/tests/test/crypto/CMakeLists.txt
+++ b/tests/test/crypto/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 include_directories(../../../external)
 

--- a/tests/test/local/CMakeLists.txt
+++ b/tests/test/local/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(tests.catapult.test.local)
 target_link_libraries(tests.catapult.test.local

--- a/tests/test/nemesis/CMakeLists.txt
+++ b/tests/test/nemesis/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(tests.catapult.test.nemesis)
 target_link_libraries(tests.catapult.test.nemesis

--- a/tests/test/net/CMakeLists.txt
+++ b/tests/test/net/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(tests.catapult.test.net mocks)
 target_link_libraries(tests.catapult.test.net tests.catapult.test.core tests.catapult.test.crypto catapult.net)

--- a/tests/test/nodeps/CMakeLists.txt
+++ b/tests/test/nodeps/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(tests.catapult.test.nodeps)
 target_link_libraries(tests.catapult.test.nodeps catapult.utils catapult.version ${CMAKE_DL_LIBS})

--- a/tests/test/other/CMakeLists.txt
+++ b/tests/test/other/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_header_only_target(tests.catapult.test.other mocks)

--- a/tests/test/plugins/CMakeLists.txt
+++ b/tests/test/plugins/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_header_only_target(tests.catapult.test.plugins)

--- a/tests/test/tree/CMakeLists.txt
+++ b/tests/test/tree/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_header_only_target(tests.catapult.test.tree)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 include_directories(. ${CMAKE_BINARY_DIR}/inc)
 

--- a/tools/address/CMakeLists.txt
+++ b/tools/address/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_tool(address)

--- a/tools/benchmark/CMakeLists.txt
+++ b/tools/benchmark/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_tool(benchmark)

--- a/tools/health/CMakeLists.txt
+++ b/tools/health/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_tool(health)

--- a/tools/linker/CMakeLists.txt
+++ b/tools/linker/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_tool(linker)

--- a/tools/nemgen/CMakeLists.txt
+++ b/tools/nemgen/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 add_subdirectory(blockhashes)
 

--- a/tools/nemgen/blockhashes/CMakeLists.txt
+++ b/tools/nemgen/blockhashes/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 set(TARGET_NAME catapult.tools.nemgen.blockhashes)
 

--- a/tools/network/CMakeLists.txt
+++ b/tools/network/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_tool(network)
 target_link_libraries(catapult.tools.network catapult.nodediscovery)

--- a/tools/ssl/CMakeLists.txt
+++ b/tools/ssl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_tool(ssl)
 

--- a/tools/statusgen/CMakeLists.txt
+++ b/tools/statusgen/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_tool(statusgen)

--- a/tools/testvectors/CMakeLists.txt
+++ b/tools/testvectors/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_tool(testvectors)

--- a/tools/tools/CMakeLists.txt
+++ b/tools/tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_library_target(catapult.tools)
 target_link_libraries(catapult.tools ${CORE_CATAPULT_LIBS} catapult.api catapult.config catapult.net catapult.sdk catapult.version)

--- a/tools/votingkey/CMakeLists.txt
+++ b/tools/votingkey/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 catapult_define_tool(votingkey)
 target_link_libraries(catapult.tools.votingkey catapult.crypto_voting catapult.finalization)


### PR DESCRIPTION
Version of CMake shipped by Debian Buster is 3.13.
I tested the procedure README.manual (preparing _build directory) and gave no issues.
