### PR TITLE
Fix. Infinite loop found when fed with empty input.

### DIFF
--- a/tools/addressgen/main.cpp
+++ b/tools/addressgen/main.cpp
@@ -77,7 +77,7 @@ namespace catapult { namespace tools { namespace addressgen {
 
 				for (auto& descriptor : m_descriptors) {
 					auto searchString = descriptor.SearchString;
-					while (!searchString.empty() && (searchString.size() > descriptor.BestMatchSize || !descriptor.pBestKeyPair)) {
+					while (!searchString.empty() || (searchString.size() > descriptor.BestMatchSize || !descriptor.pBestKeyPair)) {
 						auto matchIndex = addressString.find(searchString);
 						auto isMatch = std::string::npos != matchIndex;
 						if (descriptor.MatchStart)


### PR DESCRIPTION
Invocation of `./catapult.tools.addressgen` hangs.
The bug can be reproduced by invoking the program without arguments. It never exits from a CPU consuming task.
gdb reveals all worker threads got trapped in the for loop lines 174-187.

commit #d0adcf0cc contains a smoking gun.

This patch changes a logic condition and the resulting behavior is the expected one for both empty and non-empty (--input) input modes.

I believe the intended boolean operator was 'OR' instead of  'AND', @Jaguar0625  ?
