### PR TITLE
Document missing build dependencies

### DIFF
--- a/docs/BUILD-conan.md
+++ b/docs/BUILD-conan.md
@@ -83,6 +83,14 @@ conan install .. --build missing
 
   Once the build finishes successfully, the tools in ``_build/bin`` are ready to use. However, the dependencies in ``_build/deps`` must be accessible so make sure to add this folder to the ``LD_LIBRARY_PATH`` environment variable (Linux) or ``DYLD_LIBRARY_PATH`` (Mac).
 
+  One way of doing this is by running this from the ``_build`` directory:
+
+  ```sh
+  export LD_LIBRARY_PATH=$PWD/deps
+  ```
+
+  You will need to run this line every new session, unless you add it at the end of your ``~/.bashrc`` or ``~/.profile`` files.
+
 * Install (Optional):
 
   The catapult tools can be made available globally by running:

--- a/docs/BUILD-conan.md
+++ b/docs/BUILD-conan.md
@@ -4,21 +4,30 @@ Following instructions should work on Mac, Linux (Ubuntu 20.04) and Windows.
 
 ## Prerequisites
 
-* **On Linux and Mac**:
+* **On Linux**:
 
-  ```sh
-  sudo apt install build-essential git cmake ninja-build
-  conan profile new default --detect
-  conan profile update settings.compiler.libcxx=libstdc++11 default
-  ```
+  1. Install the compiler:
+
+     ```sh
+     sudo apt install build-essential git cmake ninja-build
+     ```
+
+  2. Install [Conan](https://conan.io/downloads.html).
+
+  3. Set the right C++ ABI for Conan:
+
+     ```sh
+     conan profile new default --detect
+     conan profile update settings.compiler.libcxx=libstdc++11 default
+     ```
 
 * **On Windows**:
 
-  Install [Visual Studio](https://visualstudio.microsoft.com/) and [Git for Windows](https://git-scm.com/download/win).
+  1. Install [Visual Studio](https://visualstudio.microsoft.com/) and [Git for Windows](https://git-scm.com/download/win).
 
-  Run all the commands below from a command prompt that has access to Visual Studio and Git. This can be accomplished by using the "Native Tools Command Prompt" shortcut installed by Visual Studio on the Start Menu.
+     Run all commands from a command prompt that has access to Visual Studio and Git. This can be accomplished by using the "Native Tools Command Prompt" shortcut installed by Visual Studio on the Start Menu.
 
-* **On both**: Install [Conan](https://conan.io/downloads.html).
+  2. Install [Conan](https://conan.io/downloads.html).
 
 ## Step 1: Build dependencies
 
@@ -40,7 +49,7 @@ conan install .. --build missing
 ### Windows + Visual Studio
 
 > **NOTE:**
-> Make sure to use the correct ``PYTHON_EXECUTABLE`` path! Python3 is required for the build to produce some header files. If Python3 cannot be found you won't notice until more than one hour into the build process because of some missing headers. You can find your Python3 path by running ``where pyton3``.
+> Make sure to use the correct ``PYTHON_EXECUTABLE`` path! Python3 is required for the build to produce some header files. If Python3 cannot be found you won't notice until more than one hour into the build process because of some missing headers. You can find your Python3 path by running ``where python3``.
 
 * Generate project files for Visual Studio 2019:
 

--- a/docs/BUILD-conan.md
+++ b/docs/BUILD-conan.md
@@ -29,6 +29,22 @@ Following instructions should work on Mac, Linux (Ubuntu 20.04) and Windows.
 
   2. Install [Conan](https://conan.io/downloads.html).
 
+* **On Mac**:
+
+  1. Install the compiler:
+
+     ```sh
+     xcode-select —install
+     ```
+
+  2. Install build dependencies:
+
+     ```sh
+     brew install git cmake ninja
+     ```
+
+  3. Install [Conan](https://conan.io/downloads.html).
+
 ## Step 1: Build dependencies
 
 While Conan will be building and installing packages, you might want to go for a ☕ (or lunch),

--- a/docs/BUILD-conan.md
+++ b/docs/BUILD-conan.md
@@ -1,19 +1,24 @@
 # Building with Conan
 
-Following instructions should work on Mac, Linux and Windows.
+Following instructions should work on Mac, Linux (Ubuntu 20.04) and Windows.
 
 ## Prerequisites
 
-* Install [Conan](https://conan.io)
-
-* **On Linux**, if this is the first time running Conan, you need to set the right C++ ABI:
+* **On Linux and Mac**:
 
   ```sh
+  sudo apt install build-essential git cmake ninja-build
   conan profile new default --detect
   conan profile update settings.compiler.libcxx=libstdc++11 default
   ```
 
-* **On Windows**, run all the commands below from a command prompt that has access to Visual Studio and Git. This can be accomplished by using the "Native Tools Command Prompt" shortcut installed by Visual Studio on the Start Menu.
+* **On Windows**:
+
+  Install [Visual Studio](https://visualstudio.microsoft.com/) and [Git for Windows](https://git-scm.com/download/win).
+
+  Run all the commands below from a command prompt that has access to Visual Studio and Git. This can be accomplished by using the "Native Tools Command Prompt" shortcut installed by Visual Studio on the Start Menu.
+
+* **On both**: Install [Conan](https://conan.io/downloads.html).
 
 ## Step 1: Build dependencies
 
@@ -35,15 +40,15 @@ conan install .. --build missing
 ### Windows + Visual Studio
 
 > **NOTE:**
-> Make sure to use the correct ``PYTHON_EXECUTABLE`` path! Python3 is required for the build to produce some header files. If Python3 cannot be found you won't notice until more than one hour into the build process because of some missing headers.
+> Make sure to use the correct ``PYTHON_EXECUTABLE`` path! Python3 is required for the build to produce some header files. If Python3 cannot be found you won't notice until more than one hour into the build process because of some missing headers. You can find your Python3 path by running ``where pyton3``.
 
-* Generate project files for VS 2019:
+* Generate project files for Visual Studio 2019:
 
   ```sh
   cmake -G "Visual Studio 16 2019" -A x64 -DUSE_CONAN=ON -DPYTHON_EXECUTABLE:FILEPATH=X:/python3x/python.exe ..
   ```
 
-* Generate project files for VS 2017:
+* Generate project files for Visual Studio 2017:
 
   ```sh
   cmake -G "Visual Studio 15 2017 Win64" -DUSE_CONAN=ON -DPYTHON_EXECUTABLE:FILEPATH=X:/python3x/python.exe ..


### PR DESCRIPTION
Some non-developer user reported problems building because of missing dependencies.
On Ubuntu 20.04 (the Linux version stated on the onset) these dependencies are enough to build successfully, and I don't think the extra line hurts the file's readability too much.